### PR TITLE
Fixed typo for mutationHandler

### DIFF
--- a/src/impl/Document.js
+++ b/src/impl/Document.js
@@ -472,7 +472,7 @@ defineLazyProperty(impl, "Document", function() {
         // rooted.
         mutateRemove: constant(function(node) {
             // Send a single mutation event
-            if (this.mutationHander) {
+            if (this.mutationHandler) {
                 this.mutationHandler({
                     type: MUTATE_REMOVE,
                     target: node._nid


### PR DESCRIPTION
The mutationHandler in the MUTATE_REMOVE case was misspelled.

Gotta love one character pull reqeusts. :-)
