### PR TITLE
more generic path for node

### DIFF
--- a/tools/idl2domjs
+++ b/tools/idl2domjs
@@ -1,4 +1,4 @@
-#!/usr/local/bin/node
+#!/usr/bin/env node
 
 /*
  * idl2domjs: convert WebIDL interfaces into JavaScript source for dom.js

--- a/tools/idl2json
+++ b/tools/idl2json
@@ -1,4 +1,4 @@
-#!/usr/local/bin/node
+#!/usr/bin/env node
 var idl = require("fs").readFileSync(process.argv[2],"utf-8");
 try {
     var tree = require("../deps/webidl.js/node/WebIDLParser.js").Parser.parse(idl);

--- a/tools/tool_server
+++ b/tools/tool_server
@@ -1,4 +1,4 @@
-#!/usr/local/bin/node
+#!/usr/bin/env node
 
 // at the moment you have to run this from the dom.js directory, not the tools directory.
 // less hardcoded paths would be good.


### PR DESCRIPTION
default make doesn't work on debian, because of the weird path for node.
this should be more generic
