### PR TITLE
Adds 'ant' as a build dependency

### DIFF
--- a/README
+++ b/README
@@ -40,6 +40,9 @@ Install spidermonkey:
     Or, build from source following these directions:
 
         https://developer.mozilla.org/En/SpiderMonkey/Build_Documentation
+        
+Install ant:
+    https://ant.apache.org/
 
 Building
 ======


### PR DESCRIPTION
The current code base requires `ant`; this mentions that installation is needed in the README.